### PR TITLE
não adicionar reações em mensagens que começam com >

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -2,6 +2,7 @@ const {client, config} = require("..");
 
 client.on("message", msg => {
     if(msg.channel.id == config.bot.guilds.main.channels.suggestion){
+        if(msg.content.startsWith('>')) return;
         msg.react("👍");
         msg.react("👎");
     }


### PR DESCRIPTION
No canal de sugestões, não adicionar reações em mensagens que começam com >, já que geralmente é usado para fazer comentários sobre algumas sugestões.