### PR TITLE
atualizando de ".toNow()" para ".fromNow" (Eventos)

### DIFF
--- a/src/events/guild/member/join.ts
+++ b/src/events/guild/member/join.ts
@@ -52,7 +52,7 @@ function memberLog (member: GuildMember): void {
     .addFields([
       {
         name: 'Criação da conta:',
-        value: `${createdAt.format('LLLL')}\n\`${createdAt.toNow()}\``,
+        value: `${createdAt.format('LLLL')}\n\`${createdAt.fromNow()}\``,
         inline: true
       },
       {


### PR DESCRIPTION
Simplesmente atualizei como haviam pedido nas sugestões para que a forma que saia escrito seja "há tanto tempo" (já que se trata de tempo passado) em vez de "em tanto tempo", ficando mais gramaticalmente correto