### PR TITLE
Simples modificação para ficar mais bonitinho e igual o de leave

### DIFF
--- a/src/events/guild/member/join.ts
+++ b/src/events/guild/member/join.ts
@@ -73,7 +73,7 @@ function memberLog (member: GuildMember): void {
         inline: true
       }
     ])
-    .setFooter(member.id)
+    .setFooter(`ID: ${member.id}`)
   )
     .catch(console.error)
 }


### PR DESCRIPTION
É o seguinte adm, no footer da mensagem de saída tinha o ID: antes do id do usuário, ai eu só coloquei pra ficar igual